### PR TITLE
Update dependencies, update readme,  Fix storage/oauth-private.key not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@ Provides a new Laravel Passport Grant Client named `facebook_login`, allowing yo
 A new user will be created (and optionally assigned to an EnTrust role) if the email address doesn't exist.
 
 ## Installation:
-Install with composer  `composer require danjdewhurst/laravel-passport-facebook-login`
+Install with composer `composer require danjdewhurst/laravel-passport-facebook-login`
 
 ### Versions:
-* Laravel 5.4 and Passport 2.0 only supported at this time
+* Laravel 5.5 and Passport 4.0 only supported at this time
 
 ## Dependencies:
-* `"laravel/passport": "^3.0"`
-* `"facebook/graph-sdk": "^5.4"`
+* `"laravel/passport": "^4.0"`
+* `"facebook/graph-sdk": "^5.6"`
 
 ## Setup:
-* Add `Danjdewhurst\PassportFacebookLogin\FacebookLoginGrantProvider::class` to your list of providers **after** `Laravel\Passport\PassportServiceProvider`.
+### Laravel 5.5+
+Laravel uses auto-discovery.
+
+### Laravel 5.4 or lower
+Add `Danjdewhurst\PassportFacebookLogin\FacebookLoginGrantProvider::class` to your list of providers **after** `Laravel\Passport\PassportServiceProvider`.
+
 * Add `Danjdewhurst\PassportFacebookLogin\FacebookLoginTrait` Trait to your `User` model (or whatever model you have configured to work with Passport).
 * Run `php artisan vendor:publish`, this will create a `config/facebook.php` file. More options will be added here in the future.
 * Enter your Facebook App details in your `.env` file: `FACEBOOK_APP_ID` and `FACEBOOK_APP_SECRET`.
@@ -27,8 +32,12 @@ Install with composer  `composer require danjdewhurst/laravel-passport-facebook-
 
 ## How To Use:
 
-* Make a **POST** request to `https://your-site.com/oauth/token`, just like you would a **Password** or **Refresh** grant.
-* The POST body should contain `grant_type` = `facebook_login` and `fb_token` = `{token from facebook login}`.
+* Make a **POST** request to `https://your-site.com/oauth/token`.
+* The POST body should contain
+    1. `grant_type` = `facebook_login`
+    2. `fb_token` = `{token from facebook login}`.
+    3. client_id
+    4. client_secret
 * An `access_token` and `refresh_token` will be returned if successful.
 
 ## Assumptions:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     },
     "require": {
-        "laravel/passport": "^3.0",
-        "facebook/graph-sdk": "^5.4"
+        "laravel/passport": "^4.0",
+        "facebook/graph-sdk": "^5.6"
     },
     "extra": {
         "laravel": {

--- a/src/FacebookLoginGrantProvider.php
+++ b/src/FacebookLoginGrantProvider.php
@@ -30,7 +30,9 @@ class FacebookLoginGrantProvider extends PassportServiceProvider
             __DIR__.'/config/facebook.php' => config_path('facebook.php'),
         ]);
 
-        app(AuthorizationServer::class)->enableGrantType($this->makeRequestGrant(), Passport::tokensExpireIn());
+        if (file_exists(__DIR__ . '/../../../../storage/oauth-private.key')) {
+            app(AuthorizationServer::class)->enableGrantType($this->makeRequestGrant(), Passport::tokensExpireIn());
+        }
     }
 
     /**
@@ -40,6 +42,7 @@ class FacebookLoginGrantProvider extends PassportServiceProvider
      */
     public function register()
     {
+        //
     }
 
     /**


### PR DESCRIPTION
Update passport to 4.0 and facebook graph sdk to 5.6 (currently I am testing these versions and it works like a charm).

When you add this package to your project and you do a fresh pull, php crashes because it needs a oath-private.key. Of course there is no private key because you did a git pull and passport is not installed.
So to fix this issue, check if there is a private key to assume passport has been installed!

Update the readme