### PR TITLE
When you change your facebook e-mail, you can't login for now...

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Add `Danjdewhurst\PassportFacebookLogin\FacebookLoginGrantProvider::class` to yo
 ## Assumptions:
 * Your `User` model has the folowing fields:
 * * `facebook_id`
-* * `first_name`
-* * `last_name`
+* * `name`
 * * `email`
 * * `password`
 

--- a/src/FacebookLoginTrait.php
+++ b/src/FacebookLoginTrait.php
@@ -46,7 +46,8 @@ trait FacebookLoginTrait {
                 /**
                  * Create a new user if they haven't already signed up.
                  */
-                $user = $userModel::where('email', $fbUser['email'])->first();
+                $user = $userModel::where('facebook_id', $fbUser['id'])->first();
+
                 if (!$user) {
                     $user = new $userModel();
                     $user->facebook_id = $fbUser['id'];

--- a/src/FacebookLoginTrait.php
+++ b/src/FacebookLoginTrait.php
@@ -51,8 +51,7 @@ trait FacebookLoginTrait {
                 if (!$user) {
                     $user = new $userModel();
                     $user->facebook_id = $fbUser['id'];
-                    $user->first_name = $fbUser['first_name'];
-                    $user->last_name = $fbUser['last_name'];
+                    $user->name = $fbUser['first_name'] . ' ' . $fbUser['last_name'];
                     $user->email = $fbUser['email'];
                     $user->password = uniqid('fb_', true); // Random password.
                     $user->save();


### PR DESCRIPTION
After you change your facebook e-mail, you can't login anymore because the e-mail addresses wil be compared..

Comparing the facebook ids will fix this issue.

Also the user model has only a `name` property default, so I don't see any reason to keep `first_name ` and `last_name `.