### PR TITLE
Configure field names

### DIFF
--- a/src/FacebookLoginGrantProvider.php
+++ b/src/FacebookLoginGrantProvider.php
@@ -30,7 +30,7 @@ class FacebookLoginGrantProvider extends PassportServiceProvider
             __DIR__.'/config/facebook.php' => config_path('facebook.php'),
         ]);
 
-        if (file_exists(__DIR__ . '/../../../../storage/oauth-private.key')) {
+        if (file_exists(storage_path('oauth-private.key'))) {
             app(AuthorizationServer::class)->enableGrantType($this->makeRequestGrant(), Passport::tokensExpireIn());
         }
     }

--- a/src/FacebookLoginRequestGrant.php
+++ b/src/FacebookLoginRequestGrant.php
@@ -22,11 +22,10 @@ class FacebookLoginRequestGrant extends AbstractGrant
     public function __construct(
         UserRepositoryInterface $userRepository,
         RefreshTokenRepositoryInterface $refreshTokenRepository
-    )
-    {
+    ) {
         $this->setUserRepository($userRepository);
         $this->setRefreshTokenRepository($refreshTokenRepository);
-        $this->refreshTokenTTL = new \DateInterval('P1M');
+        $this->refreshTokenTTL = Passport::refreshTokensExpireIn();
     }
 
     /**
@@ -36,8 +35,7 @@ class FacebookLoginRequestGrant extends AbstractGrant
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
         \DateInterval $accessTokenTTL
-    )
-    {
+    ) {
         // Validate request
         $client = $this->validateClient($request);
         $scopes = $this->validateScopes($this->getRequestParameter('scope', $request));

--- a/src/config/facebook.php
+++ b/src/config/facebook.php
@@ -1,12 +1,37 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Application
+    |--------------------------------------------------------------------------
+    |
+    | The facebook ID and secret from the developer's page
+    |
+    */
+
     'app' => [
         'id' => env('FACEBOOK_APP_ID'),
         'secret' => env('FACEBOOK_APP_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Registration Fields
+    |--------------------------------------------------------------------------
+    |
+    | The name of the fields on the user model that need to be updated,
+    | if null, they shall not be updated. (valid for name, first_name, last_name)
+    |
+    */
+
     'registration' => [
+        'facebook_id' => 'facebook_id',
+        'email'       => 'email',
+        'password'    => 'password',
+        'first_name'  => 'first_name',
+        'last_name'   => 'last_name',
+        'name'        => 'name',
         'attach_role' => null,
     ],
 ];


### PR DESCRIPTION
This pull request allows your package to configure the name of the fields on the user model without assuming anything.

It is much more flexible and fits into every variant of the user model.

It also lets you decide between saving the complete name or first and last name by themselves.