### PR TITLE
Missing use Laravel\Passport\Passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Install with composer `composer require danjdewhurst/laravel-passport-facebook-l
 
     'registration' => [
         'facebook_id' => env('FACEBOOK_ID_COLUMN', 'facebook_id'),
+        'user_id'     => env('USER_ID', 'id'),
         'email'       => env('EMAIL_COLUMN', 'email'),
         'password'    => env('PASSWORD_COLUMN', 'password'),
         'first_name'  => env('FIRST_NAME_COLUMN', 'first_name'),
@@ -66,13 +67,6 @@ Install with composer `composer require danjdewhurst/laravel-passport-facebook-l
     3. client_id
     4. client_secret
 * An `access_token` and `refresh_token` will be returned if successful.
-
-## Assumptions:
-* Your `User` model has the folowing fields:
-* * `facebook_id`
-* * `name` or `first_name` & `last_name`
-* * `email`
-* * `password`
 
 ## Credits:
 * https://github.com/mirkco/Laravel-Passport-Facebook-Login

--- a/src/FacebookLoginRequestGrant.php
+++ b/src/FacebookLoginRequestGrant.php
@@ -12,7 +12,6 @@ use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Laravel\Passport\Passport;
 
 class FacebookLoginRequestGrant extends AbstractGrant
 {
@@ -104,7 +103,8 @@ class FacebookLoginRequestGrant extends AbstractGrant
         } else {
             throw OAuthServerException::serverError('Unable to find loginFacebook method on user model.');
         }
+        $user_id_column = config('facebook.registration.user_id', 'id');
 
-        return ($user) ? new User($user->id) : null;
+        return ($user) ? new User($user->{$user_id_column}) : null;
     }
 }

--- a/src/FacebookLoginRequestGrant.php
+++ b/src/FacebookLoginRequestGrant.php
@@ -12,6 +12,7 @@ use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Laravel\Passport\Passport;
 
 class FacebookLoginRequestGrant extends AbstractGrant
 {

--- a/src/config/facebook.php
+++ b/src/config/facebook.php
@@ -27,6 +27,7 @@ return [
 
     'registration' => [
         'facebook_id' => env('FACEBOOK_ID_COLUMN', 'facebook_id'),
+        'user_id'     => env('USER_ID', 'id'),
         'email'       => env('EMAIL_COLUMN', 'email'),
         'password'    => env('PASSWORD_COLUMN', 'password'),
         'first_name'  => env('FIRST_NAME_COLUMN', 'first_name'),


### PR DESCRIPTION
We need to add the use directive in order to use Passport::refreshTokensExpireIn();  instead of hardcoding the date.