### PR TITLE
Laravel 5.6 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "laravel/passport": "^4.0",
+        "laravel/passport": "^5.0",
         "facebook/graph-sdk": "^5.6"
     },
     "extra": {

--- a/src/FacebookLoginRequestGrant.php
+++ b/src/FacebookLoginRequestGrant.php
@@ -4,6 +4,7 @@ namespace Danjdewhurst\PassportFacebookLogin;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Bridge\User;
+use Laravel\Passport\Passport;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AbstractGrant;


### PR DESCRIPTION
Upped the Passport version to v5. Fixed a missing import. I assume it was a Facade in <v5, unfortunately this has been removed by the looks of things.