### PR TITLE
Allow newer versions of Laravel Passport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "laravel/passport": "^5.0",
+        "laravel/passport": "^5.0||^6.0||^7.0",
         "facebook/graph-sdk": "^5.6"
     }
 }


### PR DESCRIPTION
Updates the composer.json to allow for newer versions of Passport to function. This is required to be compatible with a minor Laravel version which fixes a security flaw.